### PR TITLE
validation: Don't repeat work in InvalidateBlock

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3768,6 +3768,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* pinde
                 // Do not remove candidate from the highpow_outofchain_headers cache, because it might be a descendant of the block being invalidated
                 // which needs to be marked failed later.
             }
+            // Best header updating currently doesn't use CBlockIndexWorkComparator, so nChainWork is used for consistency.
             if (best_header_needs_update &&
                 m_chainman.m_best_header->nChainWork < candidate->nChainWork) {
                 m_chainman.m_best_header = candidate;
@@ -3880,8 +3881,9 @@ void Chainstate::ResetBlockFailureFlags(CBlockIndex *pindex) {
 void Chainstate::TryAddBlockIndexCandidate(CBlockIndex* pindex)
 {
     AssertLockHeld(cs_main);
-    // The block only is a candidate for the most-work-chain if it has the same
-    // or more work than our current tip.
+    // The block only is a candidate for the most-work-chain if it has more work than
+    // our current tip, or if it has the same work and a better CBlockIndexWorkComparator
+    // tiebreak.
     if (m_chain.Tip() != nullptr && setBlockIndexCandidates.value_comp()(pindex, m_chain.Tip())) {
         return;
     }
@@ -5412,7 +5414,8 @@ void ChainstateManager::CheckBlockIndex() const
             // Two main factors determine whether pindex is a candidate in
             // setBlockIndexCandidates:
             //
-            // - If pindex has less work than the chain tip, it should not be a
+            // - If pindex has less work than the chain tip (or equal work and a worse
+            //   CBlockIndexWorkComparator tiebreak), it should not be a
             //   candidate, and this will be asserted below. Otherwise it is a
             //   potential candidate.
             //

--- a/src/validation.h
+++ b/src/validation.h
@@ -615,11 +615,13 @@ public:
     const CBlockIndex* SnapshotBase() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**
-     * The set of all CBlockIndex entries that have as much work as our current
-     * tip or more, and transaction data needed to be validated (with
+     * The set of all CBlockIndex entries that score at least as well as the
+     * tip under CBlockIndexWorkComparator (more work or same work with a tiebreak
+     * at least as good) and have transaction data that can be validated (with
      * BLOCK_VALID_TRANSACTIONS for each block and its parents back to the
-     * genesis block or an assumeutxo snapshot block). Entries may be failed,
-     * though, and pruning nodes may be missing the data for the block.
+     * genesis block or an assumeutxo snapshot block).
+     * The tip is always a member of setBlockIndexCandidates.
+     * Entries may be failed though, and pruning nodes may be missing the data for the block.
      */
     std::set<CBlockIndex*, node::CBlockIndexWorkComparator> setBlockIndexCandidates;
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -795,7 +795,7 @@ private:
     bool RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& inputs) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     void CheckForkWarningConditions() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    void InvalidChainFound(CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    void InvalidChainFound(CBlockIndex* pindexNew, bool calc_flags_and_header) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /**
      * Make mempool consistent after a reorg, by re-adding or recursively erasing


### PR DESCRIPTION
In InvalidateBlock, both the block failure flags
and m_best_header are kept up to date with each block
that is disconnected, so it's not necessary to recalculate
them at the end of this function.<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
